### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/execute_pytests.yml
+++ b/.github/workflows/execute_pytests.yml
@@ -1,4 +1,6 @@
 name: Run Python Unit Test
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/ewardq/epam_python_task/security/code-scanning/1](https://github.com/ewardq/epam_python_task/security/code-scanning/1)

The best practice is to explicitly set the `permissions` key in the workflow to the minimal required value. For a simple test workflow that only checks out code and runs tests, only `contents: read` is needed for the `GITHUB_TOKEN` (which will be issued with these limited permissions). This can be added at either the workflow root (applies to all jobs) or at the job level. Since there is only one job, either location is fine, but adding at the root level is generally recommended for clarity and future-proofing.

To fix, insert the following block after the `name` key and before `on:` (indentation at the root):
```
permissions:
  contents: read
```

No imports, methods, or code definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
